### PR TITLE
[Refactor] Spring Security - role을 쿠키로도 내려줌

### DIFF
--- a/src/main/java/com/sido/backend/member/controller/MemberController.java
+++ b/src/main/java/com/sido/backend/member/controller/MemberController.java
@@ -47,6 +47,7 @@ public class MemberController {
 			Map<String, Object> claims = JwtUtil.authenticationToClaims(authenticate);
 			String accessToken = (String) claims.get("accessToken");
 			String refreshToken = (String) claims.get("refreshToken");
+			String role = (String) claims.get("role");
 
 			// httpOnly 쿠키로 토큰 설정
 			Cookie accessCookie = new Cookie("accessToken", accessToken);
@@ -61,8 +62,14 @@ public class MemberController {
 			refreshCookie.setPath("/");
 			refreshCookie.setMaxAge(600 * 60); // 600분
 
+			Cookie roleCookie = new Cookie("role", role);
+			refreshCookie.setHttpOnly(true);
+			refreshCookie.setSecure(false);
+			refreshCookie.setPath("/");
+
 			response.addCookie(accessCookie);
 			response.addCookie(refreshCookie);
+			response.addCookie(roleCookie);
 
 			// 토큰 없이 사용자 정보만 반환
 			Map<String, Object> userInfo = new HashMap<>();
@@ -94,8 +101,15 @@ public class MemberController {
 		refreshCookie.setPath("/");
 		refreshCookie.setMaxAge(0);
 
+		Cookie roleCookie = new Cookie("role", "role");
+		refreshCookie.setHttpOnly(true);
+		refreshCookie.setSecure(false);
+		refreshCookie.setPath("/");
+		refreshCookie.setMaxAge(0);
+
 		response.addCookie(accessCookie);
 		response.addCookie(refreshCookie);
+		response.addCookie(roleCookie);
 
 		return ResponseEntity.ok("로그아웃되었습니다.");
 	}

--- a/src/main/java/com/sido/backend/member/controller/MemberController.java
+++ b/src/main/java/com/sido/backend/member/controller/MemberController.java
@@ -63,9 +63,9 @@ public class MemberController {
 			refreshCookie.setMaxAge(600 * 60); // 600분
 
 			Cookie roleCookie = new Cookie("role", role);
-			refreshCookie.setHttpOnly(true);
-			refreshCookie.setSecure(false);
-			refreshCookie.setPath("/");
+			roleCookie.setHttpOnly(true);
+			roleCookie.setSecure(false);
+			roleCookie.setPath("/");
 
 			response.addCookie(accessCookie);
 			response.addCookie(refreshCookie);
@@ -102,10 +102,10 @@ public class MemberController {
 		refreshCookie.setMaxAge(0);
 
 		Cookie roleCookie = new Cookie("role", "role");
-		refreshCookie.setHttpOnly(true);
-		refreshCookie.setSecure(false);
-		refreshCookie.setPath("/");
-		refreshCookie.setMaxAge(0);
+		roleCookie.setHttpOnly(true);
+		roleCookie.setSecure(false);
+		roleCookie.setPath("/");
+		roleCookie.setMaxAge(0);
 
 		response.addCookie(accessCookie);
 		response.addCookie(refreshCookie);


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

## 📋 작업 사항

원래는 `role`을 login 응답으로만 주고, 프론트에서는 그걸 로컬 스토리지에 저장해서 `isAdmin` 여부를 판단하려고 했는데
서버 컴포넌트에서 로컬 스토리지에 접근을 할 수 없더라고요
그래서 서버 컴포넌트에서 접근할 수 있는 쿠키로도 `role`을 내려주기로 했습니다! 

<br>

## 📸 구현 결과

<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<br>

## 💬 기타

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

<br>
<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
