### PR TITLE
[Feat] 회원가입 Api 구현

### DIFF
--- a/src/main/java/com/sido/backend/config/SecurityConfig.java
+++ b/src/main/java/com/sido/backend/config/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				// 인가 설정으로, 인증 필터인 UsernamePasswordAuthenticationFilter보다 뒷 순서
 				// 로그인, 회원가입, 문서: 공개
-				.requestMatchers("/api/users/**", "/api/members/**", "/swagger-ui/**", "/v3/api-docs/**",
+				.requestMatchers("/api/users/**", "/api/members/**", "/api/host-members/**", "/swagger-ui/**",
+					"/v3/api-docs/**",
 					"/actuator/**")
 				.permitAll()
 				// 공개 API

--- a/src/main/java/com/sido/backend/member/controller/HostMemberController.java
+++ b/src/main/java/com/sido/backend/member/controller/HostMemberController.java
@@ -1,0 +1,46 @@
+package com.sido.backend.member.controller;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sido.backend.member.dto.SignUpRequestDTO;
+import com.sido.backend.member.entity.HostMember;
+import com.sido.backend.member.service.HostMemberService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/host-members")
+@Tag(name = "사용자")
+public class HostMemberController {
+	private final HostMemberService hostMemberService;
+
+	//아이디 중복 체크 api -> 다음 스텝으로 넘어가기 전에 한 번 호출하기
+	@GetMapping("/check-id")
+	public ResponseEntity<Map<String, Object>> checkLoginId(@RequestParam String loginId) {
+		boolean exists = hostMemberService.isLoginIdTaken(loginId);
+		return ResponseEntity.ok(Map.of("exists", exists));
+	}
+
+	@Operation(summary = "관리자 회원가입")
+	@PostMapping("/signup")
+	public ResponseEntity<?> signup(@Valid @RequestBody SignUpRequestDTO dto) {
+		HostMember saved = hostMemberService.signup(dto);
+		return ResponseEntity.ok(Map.of(
+			"message", "회원가입이 완료되었습니다.",
+			"memberId", saved.getId(),
+			"loginId", saved.getLoginId()
+		));
+	}
+}

--- a/src/main/java/com/sido/backend/member/controller/HostMemberController.java
+++ b/src/main/java/com/sido/backend/member/controller/HostMemberController.java
@@ -27,6 +27,7 @@ public class HostMemberController {
 	private final HostMemberService hostMemberService;
 
 	//아이디 중복 체크 api -> 다음 스텝으로 넘어가기 전에 한 번 호출하기
+	@Operation(summary = "아이디 중복 체크")
 	@GetMapping("/check-id")
 	public ResponseEntity<Map<String, Object>> checkLoginId(@RequestParam String loginId) {
 		boolean exists = hostMemberService.isLoginIdTaken(loginId);

--- a/src/main/java/com/sido/backend/member/dto/SignUpRequestDTO.java
+++ b/src/main/java/com/sido/backend/member/dto/SignUpRequestDTO.java
@@ -1,0 +1,43 @@
+package com.sido.backend.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+
+public class SignUpRequestDTO {
+	@Schema(description = "아이디", example = "hana_user01")
+	@NotBlank(message = "아이디는 공백일 수 없습니다")
+	@Size(min = 5, max = 20, message = "아이디는 최소 5자, 최대 20자 이하여야 합니다.")
+	@Pattern(
+		regexp = "^[a-z0-9_]+$",
+		message = "아이디는 영문 소문자, 숫자, 밑줄(_)만 사용할 수 있습니다."
+	)
+	String loginId;
+
+	@Schema(description = "비밀번호", example = "Abcdef12!")
+	@NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+	@Size(min = 8, max = 20, message = "비밀번호의 길이가 8자 이상 20자 이하여야 합니다.")
+	@Pattern(
+		regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,20}$",
+		message = "비밀번호는 영문자, 숫자, 특수문자를 모두 포함해야 합니다."
+	)
+	String password;
+
+	@Schema(example = "하나마을")
+	@NotBlank
+	String villageName;
+
+	@Schema(example = "전라남도 해남")
+	@NotBlank
+	String region;
+
+	@Schema(example = "010-1234-5678")
+	@NotBlank
+	@Pattern(regexp = "^0\\d{1,2}-\\d{3,4}-\\d{4}$", message = "전화번호 양식이 올바르지 않습니다.")
+	String phone;
+
+}

--- a/src/main/java/com/sido/backend/member/repository/HostMemberRepository.java
+++ b/src/main/java/com/sido/backend/member/repository/HostMemberRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sido.backend.member.entity.HostMember;
 
-import java.util.Optional;
-
 public interface HostMemberRepository extends JpaRepository<HostMember, Long> {
+	boolean existsByLoginId(String loginId);
 }

--- a/src/main/java/com/sido/backend/member/service/HostMemberService.java
+++ b/src/main/java/com/sido/backend/member/service/HostMemberService.java
@@ -1,0 +1,10 @@
+package com.sido.backend.member.service;
+
+import com.sido.backend.member.dto.SignUpRequestDTO;
+import com.sido.backend.member.entity.HostMember;
+
+public interface HostMemberService {
+	boolean isLoginIdTaken(String loginId);
+
+	HostMember signup(SignUpRequestDTO dto);
+}

--- a/src/main/java/com/sido/backend/member/service/HostMemberServiceImpl.java
+++ b/src/main/java/com/sido/backend/member/service/HostMemberServiceImpl.java
@@ -1,0 +1,47 @@
+package com.sido.backend.member.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sido.backend.member.dto.SignUpRequestDTO;
+import com.sido.backend.member.entity.HostMember;
+import com.sido.backend.member.entity.MemberRole;
+import com.sido.backend.member.repository.HostMemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class HostMemberServiceImpl implements HostMemberService {
+	private final HostMemberRepository hostMemberRepository;
+
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	public boolean isLoginIdTaken(String loginId) {
+		return hostMemberRepository.existsByLoginId(loginId);
+	}
+
+	@Override
+	public HostMember signup(SignUpRequestDTO dto) {
+		if (hostMemberRepository.existsByLoginId(dto.getLoginId())) {
+			throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+		}
+
+		String encodedPassword = passwordEncoder.encode(dto.getPassword());
+
+		HostMember hostMember = HostMember.builder()
+			.loginId(dto.getLoginId())
+			.password(encodedPassword)
+			.villageName(dto.getVillageName())
+			.region(dto.getRegion())
+			.phone(dto.getPhone())
+			.stayCount(0)
+			.role(MemberRole.ROLE_ADMIN)
+			.build();
+
+		return hostMemberRepository.save(hostMember);
+	}
+}

--- a/src/main/java/com/sido/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sido/backend/security/JwtAuthenticationFilter.java
@@ -31,7 +31,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/api/members/signin",
-		"/api/members/signup"
+		"/api/members/signup",
+		"/api/host-members/signup",
+		"/api/host-members/check-id"
 	};
 
 	@Override
@@ -98,6 +100,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 
 			System.out.println("*** [JWT] setAuthentication principal = " + dto.getClass().getName());
+
+			filterChain.doFilter(request, response);
 
 		} catch (Exception e) {
 			response.setContentType("application/json");


### PR DESCRIPTION
## 📋 작업 사항

- 회원가입 api 구현했습니다 
-  [GET] /api/host-members/check-id  회원가입 과정에서 미리 id 중복 체크용 (boolean 리턴함)
-  [POST] /api/host-members/signup 최종 회원가입 요청 
<br>

## 📸 구현 결과

<img width="698" height="162" alt="image" src="https://github.com/user-attachments/assets/fa4a90c3-47a5-4f93-a95b-521d5b4e473f" />
<br>

## 💬 기타
- api 이름이나 Response에서 보완할 부분이 있는지 알려 주면 좋을 것 같아요 일단 프론트랑 연결하겠습니다~ 


<br>

