### PR TITLE
[Refactor] 예약 가능 날짜 조회 api 월 구분 안 하도록 (admin/도시 둘 다)

### DIFF
--- a/src/main/java/com/sido/backend/reservation/repository/ReservationDayRepository.java
+++ b/src/main/java/com/sido/backend/reservation/repository/ReservationDayRepository.java
@@ -13,9 +13,16 @@ public interface ReservationDayRepository extends JpaRepository<ReservationDay, 
 	void deleteByReservationId(Long reservationId);
 
 	@Query("""
-			select rd.date from ReservationDay rd
-				where rd.stay.id = :stayId
-					and rd.date in :dates
+			SELECT rd.date FROM ReservationDay rd
+				WHERE rd.stay.id = :stayId
+					AND rd.date IN :dates
 		""")
 	List<LocalDate> findReservedDatesIn(@Param("stayId") Long stayId, @Param("dates") List<LocalDate> dates);
+
+	@Query("""
+			SELECT rd.date FROM ReservationDay rd
+				WHERE rd.stay.id = :stayId
+				ORDER BY rd.date ASC
+		""")
+	List<LocalDate> findAllReserved(Long stayId);
 }

--- a/src/main/java/com/sido/backend/stay/controller/StayAdminController.java
+++ b/src/main/java/com/sido/backend/stay/controller/StayAdminController.java
@@ -1,11 +1,9 @@
 package com.sido.backend.stay.controller;
 
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 
 import org.springframework.data.domain.PageRequest;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,8 +17,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.sido.backend.stay.dto.OpenAndReservedDatesDTO;
 import com.sido.backend.common.dto.PageResponseDTO;
+import com.sido.backend.stay.dto.OpenAndReservedDatesDTO;
 import com.sido.backend.stay.dto.StayCreateDTO;
 import com.sido.backend.stay.dto.StayResponseDTO;
 import com.sido.backend.stay.dto.StayResponseDetailDTO;
@@ -85,13 +83,11 @@ public class StayAdminController {
 		return ResponseEntity.noContent().build();
 	}
 
-	@Operation(summary = "월별 오픈한 날짜 & 예약된 날짜 조회", description = "시골 관리자: 사랑방 목록 관리- 예약 가능 날짜 변경하기")
+	@Operation(summary = "오픈한 날짜 & 예약된 날짜 조회", description = "시골 관리자: 사랑방 목록 관리- 예약 가능 날짜 변경하기")
 	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	@GetMapping("/{stayId}/open-dates")
-	public ResponseEntity<OpenAndReservedDatesDTO> getOpenAndReservedDatesByMonth(@PathVariable Long stayId,
-		@Schema(example = "2025-09") @DateTimeFormat(pattern = "yyyy-MM") @RequestParam(required = false)
-		YearMonth month) {
-		OpenAndReservedDatesDTO openAndReservedDates = stayService.getOpenAndReservedDatesByMonth(stayId, month);
+	public ResponseEntity<OpenAndReservedDatesDTO> getOpenAndReservedDates(@PathVariable Long stayId) {
+		OpenAndReservedDatesDTO openAndReservedDates = stayService.getOpenAndReservedDates(stayId);
 		return ResponseEntity.ok(openAndReservedDates);
 	}
 

--- a/src/main/java/com/sido/backend/stay/controller/StayController.java
+++ b/src/main/java/com/sido/backend/stay/controller/StayController.java
@@ -1,10 +1,8 @@
 package com.sido.backend.stay.controller;
 
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,7 +18,6 @@ import com.sido.backend.stay.entity.Stay;
 import com.sido.backend.stay.service.StayService;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -51,12 +48,10 @@ public class StayController {
 		return ResponseEntity.ok(pagedStaysDTO);
 	}
 
-	@Operation(summary = "월별 예약 가능 날짜 조회")
+	@Operation(summary = "예약 가능 날짜 조회")
 	@GetMapping("/{stayId}/available-dates")
-	public ResponseEntity<AvailDatesDTO> getAvailableDatesByMonth(@PathVariable("stayId") Long stayId,
-		@Schema(example = "2025-09") @DateTimeFormat(pattern = "yyyy-MM") @RequestParam(required = false)
-		YearMonth month) {
-		AvailDatesDTO availDatesDTO = stayService.getAvailableDatesByMonth(stayId, month);
+	public ResponseEntity<AvailDatesDTO> getAvailableDates(@PathVariable("stayId") Long stayId) {
+		AvailDatesDTO availDatesDTO = stayService.getAvailableDates(stayId);
 		return ResponseEntity.ok(availDatesDTO);
 	}
 

--- a/src/main/java/com/sido/backend/stay/dto/AvailDatesDTO.java
+++ b/src/main/java/com/sido/backend/stay/dto/AvailDatesDTO.java
@@ -1,23 +1,9 @@
 package com.sido.backend.stay.dto;
 
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-@Getter
-@Setter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class AvailDatesDTO {
-	private YearMonth yearMonth;
-	private List<LocalDate> dates;
-	private boolean hasPrev;
-	private boolean hasNext;
+public record AvailDatesDTO(
+	List<LocalDate> dates
+) {
 }

--- a/src/main/java/com/sido/backend/stay/dto/OpenAndReservedDatesDTO.java
+++ b/src/main/java/com/sido/backend/stay/dto/OpenAndReservedDatesDTO.java
@@ -1,24 +1,10 @@
 package com.sido.backend.stay.dto;
 
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class OpenAndReservedDatesDTO {
-	private YearMonth yearMonth;
-	private List<LocalDate> openDates;
-	private List<LocalDate> reservedDates;
-	private boolean hasOpenPrev;
-	private boolean hasOpenNext;
-	private boolean hasReservedPrev;
-	private boolean hasReservedNext;
+public record OpenAndReservedDatesDTO(
+	List<LocalDate> openDates,
+	List<LocalDate> reservedDates
+) {
 }

--- a/src/main/java/com/sido/backend/stay/repository/StayAvailDateRepository.java
+++ b/src/main/java/com/sido/backend/stay/repository/StayAvailDateRepository.java
@@ -15,7 +15,11 @@ public interface StayAvailDateRepository extends JpaRepository<StayAvailDate, Lo
 	 * 오픈
 	 */
 	// 오픈일 전체 조회
-	@Query("select sa.availableDate from StayAvailDate sa where sa.stay.id = :stayId")
+	@Query("""
+		select sa.availableDate from StayAvailDate sa
+			where sa.stay.id = :stayId
+			order by sa.availableDate asc
+		""")
 	List<LocalDate> findAllDatesByStayId(@Param("stayId") Long stayId);
 
 	// [start, end) 기간 내 오픈한 날짜 목록 조회
@@ -29,7 +33,7 @@ public interface StayAvailDateRepository extends JpaRepository<StayAvailDate, Lo
 	List<LocalDate> findOpenInRange(@Param("stayId") Long stayId, @Param("start") LocalDate start,
 		@Param("endExclusive") LocalDate endExclusive);
 
-	// before (포함) 이전에 오픈한 날짜 목록 조회
+	// before(포함) 이전에 오픈한 날짜 목록 조회
 	@Query("""
 		select sa.availableDate from StayAvailDate sa
 			where sa.stay.id = :stayId
@@ -37,6 +41,15 @@ public interface StayAvailDateRepository extends JpaRepository<StayAvailDate, Lo
 			order by sa.availableDate asc
 		""")
 	List<LocalDate> findOpenOnBefore(@Param("stayId") Long stayId, @Param("before") LocalDate before);
+
+	// after(포함) 이후에 오픈한 날짜 목록 조회
+	@Query("""
+		select sa.availableDate from StayAvailDate sa
+			where sa.stay.id = :stayId
+				and sa.availableDate >= :after
+			order by sa.availableDate asc
+		""")
+	List<LocalDate> findOpenOnAfter(@Param("stayId") Long stayId, @Param("after") LocalDate after);
 
 	// [start, end) 기간 내 오픈한 날짜 있는지
 	boolean existsByStayIdAndAvailableDateGreaterThanEqualAndAvailableDateLessThan(Long stayId, LocalDate start,
@@ -62,6 +75,20 @@ public interface StayAvailDateRepository extends JpaRepository<StayAvailDate, Lo
 			order by sa.availableDate asc
 		""")
 	List<LocalDate> findOpenAndUnreservedInRange(@Param("stayId") Long stayId, LocalDate start, LocalDate endExclusive);
+
+	// after(포함) 이후 '오픈 + 예약 미점유' 날짜 목록 조회
+	@Query("""
+		select sa.availableDate from StayAvailDate sa
+			where sa.stay.id = :stayId
+				and sa.availableDate >= :after
+				and not exists (
+					select 1 from ReservationDay rd
+						where rd.stay.id = sa.stay.id
+							and rd.date = sa.availableDate
+					)
+			order by sa.availableDate asc
+		""")
+	List<LocalDate> findOpenAndUnreservedOnAfter(@Param("stayId") Long stayId, @Param("after") LocalDate after);
 
 	// [start, end) 기간 내 '오픈 + 예약 미점유' 날짜 개수
 	@Query("""
@@ -90,65 +117,6 @@ public interface StayAvailDateRepository extends JpaRepository<StayAvailDate, Lo
 					)
 		""")
 	long countOpenAndUnreservedOnOrAfter(@Param("stayId") Long stayId, @Param("end") LocalDate end);
-
-	/**
-	 * 오픈 + 예약 점유
-	 */
-	// [start, end) 기간 내 '오픈 + 예약 점유' 날짜 목록 조회
-	@Query("""
-		select sa.availableDate from StayAvailDate sa
-			where sa.stay.id = :stayId
-				and sa.availableDate >= :start
-				and sa.availableDate < :endExclusive
-				and exists (
-					select 1 from ReservationDay rd
-						where rd.stay.id = sa.stay.id
-							and rd.date = sa.availableDate
-					)
-			order by sa.availableDate asc
-		""")
-	List<LocalDate> findOpenAndReservedInRange(@Param("stayId") Long stayId, LocalDate start, LocalDate endExclusive);
-
-	// [start, end) 기간 내 '오픈 + 예약 점유' 날짜 개수
-	@Query("""
-		select count(sa) from StayAvailDate sa
-			where sa.stay.id = :stayId
-				and sa.availableDate >= :start
-				and sa.availableDate < :endExclusive
-				and exists (
-					select 1 from ReservationDay rd
-						where rd.stay.id = sa.stay.id
-							and rd.date = sa.availableDate
-					)
-		""")
-	long countOpenAndReservedInRange(@Param("stayId") Long stayId, @Param("start") LocalDate start,
-		@Param("endExclusive") LocalDate endExclusive);
-
-	// start(미포함) 이전 '오픈 + 예약 점유' 날짜 개수
-	@Query("""
-		select count(sa) from StayAvailDate sa
-			where sa.stay.id = :stayId
-				and sa.availableDate < :start
-				and exists (
-					select 1 from ReservationDay rd
-						where rd.stay.id = sa.stay.id
-							and rd.date = sa.availableDate
-					)
-		""")
-	long countOpenAndReservedBefore(@Param("stayId") Long stayId, @Param("start") LocalDate start);
-
-	// end 이후 '오픈 + 예약 점유' 날짜 개수
-	@Query("""
-		select count(sa) from StayAvailDate sa
-			where sa.stay.id = :stayId
-				and sa.availableDate >= :end
-				and exists (
-					select 1 from ReservationDay rd
-						where rd.stay.id = sa.stay.id
-							and rd.date = sa.availableDate
-					)
-		""")
-	long countOpenAndReservedOnOrAfter(@Param("stayId") Long stayId, @Param("end") LocalDate end);
 
 	@Modifying
 	@Query("delete from StayAvailDate sa where sa.stay.id = :stayId")

--- a/src/main/java/com/sido/backend/stay/service/StayService.java
+++ b/src/main/java/com/sido/backend/stay/service/StayService.java
@@ -1,7 +1,6 @@
 package com.sido.backend.stay.service;
 
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
@@ -30,13 +29,13 @@ public interface StayService {
 
 	StayUpdateDTO editStay(long stayId, long memberId, StayUpdateDTO stayDTO);
 
-	AvailDatesDTO getAvailableDatesByMonth(Long stayId, YearMonth yearMonth);
+	AvailDatesDTO getAvailableDates(Long stayId);
 
 	StayResponseDetailDTO getStayDetail(Long stayId, LocalDate startDate, LocalDate endDate);
 
 	void deleteStay(Long stayId);
 
-	OpenAndReservedDatesDTO getOpenAndReservedDatesByMonth(Long stayId, YearMonth yearMonth);
+	OpenAndReservedDatesDTO getOpenAndReservedDates(Long stayId);
 
 	OpenAndReservedDatesDTO updateOpenDates(Long stayId, List<LocalDate> dates);
 }

--- a/src/main/java/com/sido/backend/stay/service/StayServiceImpl.java
+++ b/src/main/java/com/sido/backend/stay/service/StayServiceImpl.java
@@ -40,7 +40,6 @@ import com.sido.backend.stay.repository.StayAvailDateRepository;
 import com.sido.backend.stay.repository.StayImageRepository;
 import com.sido.backend.stay.repository.StayRepository;
 
-import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -61,7 +60,6 @@ public class StayServiceImpl implements StayService {
 	private final StayAvailDateRepository stayAvailDateRepository;
 	private final ReservationDayRepository reservationDayRepository;
 	private final HostMemberRepository hostMemberRepository;
-	private final EntityManagerFactory entityManagerFactory;
 	@Value("${app.s3.publicBaseUrl}")
 	private String publicBaseUrl;
 	@Value("${app.s3.bucket}")
@@ -167,14 +165,14 @@ public class StayServiceImpl implements StayService {
 	}
 
 	@Override
-	public AvailDatesDTO getAvailableDatesByMonth(Long stayId, YearMonth yearMonth) {
+	public AvailDatesDTO getAvailableDates(Long stayId) {
 		stayRepository.findById(stayId).orElseThrow(
 			() -> new EntityNotFoundException("해당 사랑방을 찾을 수 없습니다.")
 		);
 
-		MonthContext monthCtx = MonthContext.of(yearMonth);
+		List<LocalDate> availableDates = stayAvailDateRepository.findOpenAndUnreservedOnAfter(stayId, LocalDate.now());
 
-		return buildAvailableCalendar(stayId, monthCtx);
+		return new AvailDatesDTO(availableDates);
 	}
 
 	@Override
@@ -212,14 +210,15 @@ public class StayServiceImpl implements StayService {
 	}
 
 	@Override
-	public OpenAndReservedDatesDTO getOpenAndReservedDatesByMonth(Long stayId, YearMonth yearMonth) {
+	public OpenAndReservedDatesDTO getOpenAndReservedDates(Long stayId) {
 		stayRepository.findById(stayId).orElseThrow(
 			() -> new EntityNotFoundException("해당 사랑방을 찾을 수 없습니다.")
 		);
 
-		MonthContext monthCtx = MonthContext.of(yearMonth);
+		List<LocalDate> openDates = stayAvailDateRepository.findOpenOnAfter(stayId, LocalDate.now()); // 오픈된 날짜들(오늘 이후만)
+		List<LocalDate> reservedDates = reservationDayRepository.findAllReserved(stayId); // 예약된 날짜들 (과거 포함 전체)
 
-		return buildOpenAndReservedCalendar(stayId, monthCtx);
+		return new OpenAndReservedDatesDTO(openDates, reservedDates);
 	}
 
 	@Override
@@ -229,6 +228,7 @@ public class StayServiceImpl implements StayService {
 			() -> new EntityNotFoundException("해당 사랑방을 찾을 수 없습니다.")
 		);
 
+		// 1) 업데이트할 날짜들 가공
 		// 오늘 이전은 변경 불가
 		List<LocalDate> openDatesBeforeToday = stayAvailDateRepository.findOpenOnBefore(stayId, LocalDate.now());
 		log.debug("openDatesBeforeToday = {}", openDatesBeforeToday);
@@ -242,7 +242,7 @@ public class StayServiceImpl implements StayService {
 			.toList();
 		log.debug("updateDates = {}", updateDates);
 
-		// 예약된 날짜 삭제 불가 검증
+		// 2) 예약된 날짜 삭제 불가 검증
 		// 현재 오픈일 전체
 		List<LocalDate> current = stayAvailDateRepository.findAllDatesByStayId(stayId);
 
@@ -259,9 +259,11 @@ public class StayServiceImpl implements StayService {
 			throw new ConflictException("이미 예약된 날짜는 삭제할 수 없습니다: " + reservedWillBeDeleted);
 		}
 
+		// 3) 현재 오픈 날짜 전체 삭제
 		int deletedCnt = stayAvailDateRepository.deleteAllByStayId(stayId);
 		log.info("updateOpenDates: deletedCnt = {}", deletedCnt);
 
+		// 4) 가공된 업데이트 날짜들 insert
 		List<StayAvailDate> stayAvailDates = updateDates.stream()
 			.map(d -> StayAvailDate.builder()
 				.availableDate(d)
@@ -271,9 +273,11 @@ public class StayServiceImpl implements StayService {
 
 		stayAvailDateRepository.saveAll(stayAvailDates);
 
-		MonthContext monthCtx = MonthContext.of(YearMonth.now());
+		List<LocalDate> openDates = stayAvailDateRepository.findOpenOnAfter(stayId,
+			LocalDate.now()); // 오픈된 날짜들 (오늘 이후만)
+		List<LocalDate> reserveDates = reservationDayRepository.findAllReserved(stayId); // 예약된 날짜들 (과거 포함 전체)
 
-		return buildOpenAndReservedCalendar(stayId, monthCtx);
+		return new OpenAndReservedDatesDTO(openDates, reserveDates);
 	}
 
 	private StayResponseDTO toResponseDTO(Object[] tuple) {
@@ -331,81 +335,6 @@ public class StayServiceImpl implements StayService {
 			.build();
 	}
 
-	private AvailDatesDTO buildAvailableCalendar(Long stayId, MonthContext monthCtx) {
-		List<LocalDate> dates;
-		boolean hasPrev;
-		boolean hasNext;
-
-		if (monthCtx.isPast()) {
-			// 과거 달: 항상 빈 목록, 좌측 이동 불가
-			dates = List.of();
-			hasPrev = false;
-			hasNext = stayAvailDateRepository.countOpenAndUnreservedOnOrAfter(stayId, monthCtx.today) > 0;
-		} else if (monthCtx.isCurrent()) {
-			// 이번 달
-			dates = stayAvailDateRepository.findOpenAndUnreservedInRange(stayId, monthCtx.today, monthCtx.monthEndEx);
-			hasPrev = false;
-			hasNext = stayAvailDateRepository.countOpenAndUnreservedOnOrAfter(stayId, monthCtx.monthEndEx) > 0;
-		} else {
-			// 미래 달
-			dates = stayAvailDateRepository.findOpenAndUnreservedInRange(stayId, monthCtx.monthStart,
-				monthCtx.monthEndEx);
-			hasPrev =
-				stayAvailDateRepository.countOpenAndUnreservedInRange(stayId, monthCtx.today, monthCtx.monthStart) > 0;
-			hasNext = stayAvailDateRepository.countOpenAndUnreservedOnOrAfter(stayId, monthCtx.monthEndEx) > 0;
-		}
-
-		return AvailDatesDTO.builder()
-			.yearMonth(monthCtx.target)
-			.dates(dates)
-			.hasPrev(hasPrev)
-			.hasNext(hasNext)
-			.build();
-	}
-
-	private OpenAndReservedDatesDTO buildOpenAndReservedCalendar(Long stayId, MonthContext monthCtx) {
-		List<LocalDate> openDates;
-		boolean hasOpenPrev;
-		boolean hasOpenNext;
-
-		if (monthCtx.isPast()) {
-			// 과거 달: 항상 빈 목록, 좌측 이동 불가
-			openDates = List.of();
-			hasOpenPrev = false;
-			hasOpenNext = stayAvailDateRepository.existsByStayIdAndAvailableDateGreaterThanEqual(stayId,
-				monthCtx.today);
-		} else if (monthCtx.isCurrent()) {
-			// 이번 달
-			openDates = stayAvailDateRepository.findOpenInRange(stayId, monthCtx.today, monthCtx.monthEndEx);
-			hasOpenPrev = false;
-			hasOpenNext = stayAvailDateRepository.existsByStayIdAndAvailableDateGreaterThanEqual(stayId,
-				monthCtx.monthEndEx);
-		} else {
-			// 미래 달
-			openDates = stayAvailDateRepository.findOpenInRange(stayId, monthCtx.monthStart, monthCtx.monthEndEx);
-			hasOpenPrev = stayAvailDateRepository.existsByStayIdAndAvailableDateGreaterThanEqualAndAvailableDateLessThan(
-				stayId, monthCtx.today, monthCtx.monthStart);
-			hasOpenNext = stayAvailDateRepository.existsByStayIdAndAvailableDateGreaterThanEqual(stayId,
-				monthCtx.monthEndEx);
-		}
-
-		List<LocalDate> reservedDates = stayAvailDateRepository.findOpenAndReservedInRange(stayId, monthCtx.monthStart,
-			monthCtx.monthEndEx);
-		boolean hasReservedPrev = stayAvailDateRepository.countOpenAndReservedBefore(stayId, monthCtx.monthStart) > 0;
-		boolean hasReservedNext =
-			stayAvailDateRepository.countOpenAndReservedOnOrAfter(stayId, monthCtx.monthEndEx) > 0;
-
-		return OpenAndReservedDatesDTO.builder()
-			.yearMonth(monthCtx.target)
-			.openDates(openDates)
-			.hasOpenPrev(hasOpenPrev)
-			.hasOpenNext(hasOpenNext)
-			.reservedDates(reservedDates)
-			.hasReservedPrev(hasReservedPrev)
-			.hasReservedNext(hasReservedNext)
-			.build();
-	}
-
 	//s3 관련 함수들
 	private void validateTempKey(String key) {
 		if (key == null || !key.startsWith("temp/") || key.contains("..")) {
@@ -446,32 +375,5 @@ public class StayServiceImpl implements StayService {
 					.toList())
 				.build())
 			.build());
-	}
-
-	private record MonthContext(
-		LocalDate today,
-		YearMonth nowYM,
-		YearMonth target,
-		LocalDate monthStart,
-		LocalDate monthEndEx
-	) {
-		static MonthContext of(YearMonth input) {
-			LocalDate today = LocalDate.now();
-			YearMonth nowYM = YearMonth.from(today);
-			YearMonth target = (input == null) ? nowYM : input; // null이면 이번달
-
-			LocalDate monthStart = target.atDay(1);
-			LocalDate monthEndEx = target.plusMonths(1).atDay(1); // [monthStart, monthEndEx)
-
-			return new MonthContext(today, nowYM, target, monthStart, monthEndEx);
-		}
-
-		boolean isPast() {
-			return target.isBefore(nowYM);
-		}
-
-		boolean isCurrent() {
-			return target.equals(nowYM);
-		}
 	}
 }


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

## 📋 작업 사항
월별로 나누지 않고 전체 리스트로 보낼 수  있도록 response 수정하였습니다. 월별로 보내지 않아도 돼서 hasPrev, hasNext는 불필요해서 제거했습니다.
예약이 되어 있는 날짜들은 StayAvailDateRepository보다 ReservationDayRepository가 더 적절한 것 같아서 옯겼습니다.
코드를 대거 삭제하면서 사용 안 하는 메소드가 많아졌는데 활용도 높아보여서 일단은 지우지 않고 놔두겠습니다.
<!-- 작업 내용을 간략히 설명해주세요 -->

<br>

## 📸 구현 결과

<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<br>

## 💬 기타

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

<br>
<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
