### PR TITLE
[Feat] 사랑방마다 예약목록 조회

### DIFF
--- a/src/main/java/com/sido/backend/reservation/controller/ReservationAdminController.java
+++ b/src/main/java/com/sido/backend/reservation/controller/ReservationAdminController.java
@@ -60,9 +60,10 @@ public class ReservationAdminController {
 		@AuthenticationPrincipal(expression = "memberId") Long memberId,
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "10") int listSize,
-		@RequestParam(defaultValue = "ALL") ReservationListFilter filter) {
+		@RequestParam(defaultValue = "ALL") ReservationListFilter filter,
+		@RequestParam(required = false) Long stayId) {
 		PageResponseDTO<ReservationListItemDTO, Reservation> reservationList =
-			reservationService.getAdminReservationList(memberId, page, listSize, filter);
+			reservationService.getAdminReservationList(memberId, page, listSize, filter, stayId);
 		return ResponseEntity.ok(reservationList);
 	}
 }

--- a/src/main/java/com/sido/backend/reservation/repository/ReservationQDslRepository.java
+++ b/src/main/java/com/sido/backend/reservation/repository/ReservationQDslRepository.java
@@ -11,7 +11,7 @@ import com.sido.backend.reservation.entity.Reservation;
 public interface ReservationQDslRepository {
 	Slice<Reservation> findList(Long memberId, ReservationListFilter filter, Pageable pageable);
 
-	Slice<Reservation> findAdminList(Long memberId, ReservationListFilter filter, Pageable pageable);
+	Slice<Reservation> findAdminList(Long memberId, ReservationListFilter filter, Long stayId, Pageable pageable);
 
 	long bulkUpdateVisitStatus(LocalDate today);
 }

--- a/src/main/java/com/sido/backend/reservation/repository/ReservationQDslRepositoryImpl.java
+++ b/src/main/java/com/sido/backend/reservation/repository/ReservationQDslRepositoryImpl.java
@@ -38,10 +38,16 @@ public class ReservationQDslRepositoryImpl implements ReservationQDslRepository 
 	}
 
 	@Override
-	public Slice<Reservation> findAdminList(Long memberId, ReservationListFilter filter, Pageable pageable) {
+	public Slice<Reservation> findAdminList(Long memberId, ReservationListFilter filter, Long stayId,
+		Pageable pageable) {
 		QReservation qr = QReservation.reservation;
 
 		BooleanBuilder where = new BooleanBuilder().and(qr.stay.host.id.eq(memberId));
+
+		// stayId가 있으면 필터링 추가
+		if (stayId != null) {
+			where.and(qr.stay.id.eq(stayId));
+		}
 
 		return findCommon(where, filter, pageable);
 	}

--- a/src/main/java/com/sido/backend/reservation/service/ReservationService.java
+++ b/src/main/java/com/sido/backend/reservation/service/ReservationService.java
@@ -31,5 +31,5 @@ public interface ReservationService {
 	ReservationNextDTO getNextReservation(Long memberId);
 
 	PageResponseDTO<ReservationListItemDTO, Reservation> getAdminReservationList(Long memberId, int page, int listSize,
-		ReservationListFilter filter);
+		ReservationListFilter filter, Long stayId);
 }

--- a/src/main/java/com/sido/backend/reservation/service/ReservationServiceImpl.java
+++ b/src/main/java/com/sido/backend/reservation/service/ReservationServiceImpl.java
@@ -307,13 +307,14 @@ public class ReservationServiceImpl implements ReservationService {
 
 	@Override
 	public PageResponseDTO<ReservationListItemDTO, Reservation> getAdminReservationList(Long memberId, int page,
-		int listSize, ReservationListFilter filter) {
+		int listSize, ReservationListFilter filter, Long stayId) {
 		hostMemberRepository.findById(memberId).orElseThrow(
 			() -> new EntityNotFoundException("해당 호스트를 찾을 수 없습니다.")
 		);
 
 		Pageable pageable = PageRequest.of(page - 1, listSize);
-		Slice<Reservation> reservationSlice = reservationQDslRepository.findAdminList(memberId, filter, pageable);
+		Slice<Reservation> reservationSlice = reservationQDslRepository.findAdminList(memberId, filter, stayId,
+			pageable);
 
 		return new PageResponseDTO<>(reservationSlice, this::toListItemDTO);
 	}


### PR DESCRIPTION
<!-- PR 제목은 '[Feat] 작업 내용' 과 같은 형태로 작성해주세요.  -->

## 📋 작업 사항
기존에 있던 우리 마을 예약 목록에서 파라미터만 추가하여 사랑방별 예약목록을 볼 수 있게 하였습니다.
`@RequestParam(required=false)`로 해놓았기 때문에 전체 예약 볼 때엔 stayId가 없어도 됩니다.
<!-- 작업 내용을 간략히 설명해주세요 -->

<br>

## 📸 구현 결과

<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

<br>

## 💬 기타

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->

<br>
<!-- ⚠️ 잠깐 !!!! -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
